### PR TITLE
Fix bug where speculation corrupts when no queue provided at start

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -72,7 +72,10 @@ pub async fn run(
             }
             FrontendMessage::NewPiece { piece } => {
                 if let Some(mut msg) = waiting_on_first_piece.take() {
-                    if let FrontendMessage::Start { queue, .. } = &mut msg {
+                    if let FrontendMessage::Start { queue, randomizer, .. } = &mut msg {
+                        if let RandomizerState::SevenBag { bag_state } = randomizer {
+                            bag_state.retain(|p| p != &piece);
+                        }
                         queue.push(piece);
                         bot.start(create_bot(msg));
                     } else {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -48,7 +48,7 @@ pub async fn run(
                 if hold.is_none() && queue.is_empty() {
                     waiting_on_first_piece = Some(msg);
                 } else {
-                    bot.start(create_bot(msg));
+                    bot.start(create_bot(msg, None));
                 }
             }
             FrontendMessage::Stop => {
@@ -72,9 +72,8 @@ pub async fn run(
             }
             FrontendMessage::NewPiece { piece } => {
                 if let Some(mut msg) = waiting_on_first_piece.take() {
-                    if let FrontendMessage::Start { queue, .. } = &mut msg {
-                        queue.push(piece);
-                        bot.start(create_bot(msg));
+                    if let FrontendMessage::Start { .. } = &mut msg {
+                        bot.start(create_bot(msg, Some(piece)));
                     } else {
                         unreachable!()
                     }
@@ -90,16 +89,19 @@ pub async fn run(
     }
 }
 
-fn create_bot(start_msg: FrontendMessage) -> Bot {
+fn create_bot(start_msg: FrontendMessage, first_piece: Option<tbp::Piece>) -> Bot {
     if let FrontendMessage::Start {
         hold,
-        queue,
+        mut queue,
         combo,
         back_to_back,
         board,
         randomizer,
     } = start_msg
     {
+        if let Some(first_piece) = first_piece {
+            queue.push(first_piece);
+        }
         let mut queue = queue.into_iter().map(Into::into);
         let reserve = hold.map_or_else(|| queue.next().unwrap(), Into::into);
         let queue: Vec<_> = queue.collect();
@@ -109,6 +111,10 @@ fn create_bot(start_msg: FrontendMessage) -> Bot {
         match randomizer {
             RandomizerState::SevenBag { bag_state } => {
                 let mut bs: EnumSet<_> = bag_state.into_iter().map(Piece::from).collect();
+                if let Some(first_piece) = first_piece {
+                    bs.remove(Piece::from(first_piece));
+                }
+
                 for &p in queue.iter().rev() {
                     if bs == EnumSet::all() {
                         bs = EnumSet::empty();


### PR DESCRIPTION
I noticed a bug that after few moves, CC2 returns a `suggestion` message with no moves. (moves.length = 0)

When the piece queue was empty at the `start` message, CC2 delays the execution of `bot.start()`.
After the first `new_piece` message, it will append the first piece to the queue and continue starting up.

But this causes a problem if `seven_bag` randomizer is used because this does not remove the first piece from `bag_state`. This state is invalid and makes speculation corrupted.

This PR fixes this bug by modifying the code to remove the first piece from `bag_state` correctly.

(Sorry if my English is unclear)